### PR TITLE
현장 및 프로젝트 등 수정

### DIFF
--- a/src/assets/css/SiteDetail.css
+++ b/src/assets/css/SiteDetail.css
@@ -176,7 +176,7 @@
 .read-only-input {
     width: 100%;
     padding: 0rem 0.5rem;
-    height: 35px;
+    /* height: 35px; */
     display: flex;
     align-items: center;
     border-radius: 4px;

--- a/src/component/layout/content/management/schedule/AddDetailSchedule.jsx
+++ b/src/component/layout/content/management/schedule/AddDetailSchedule.jsx
@@ -267,6 +267,9 @@ const AddDetailSchedule = ({ isOpen, clickDate, exitBtnClick, restSaveBtnClick, 
                                             <label style={{ marginRight: "5px", fontWeight: "bold", width: "110px" }}>프로젝트</label>
                                             <div style={{ flex: 1 }}>
                                                 <div style={{height: "40px", display: "flex", alignItems: "center", width: "100%" }}>
+                                                    { nonRest ?
+                                                    <div>{projectOptions.find(item => item.value === formData.jno)?.label}</div>
+                                                    :
                                                     <Select
                                                         onChange={(e) => onChangeFormData("jno", e.value)}
                                                         options={projectOptions || []} 
@@ -285,6 +288,7 @@ const AddDetailSchedule = ({ isOpen, clickDate, exitBtnClick, restSaveBtnClick, 
                                                             }),
                                                         }}
                                                     />
+                                                    }
                                                 </div>
                                             </div>
                                         </div>

--- a/src/component/layout/content/management/schedule/DetailSchedule.jsx
+++ b/src/component/layout/content/management/schedule/DetailSchedule.jsx
@@ -130,6 +130,7 @@ const DetailSchedule = ({isOpen, isRest, restDates, dailyJobs, clickDate, exitBt
 
         setEdit("J");
         setRemove("N");
+        setIsEdit(false);
         setInitData({...item, date: dateUtil.format(item.date)});
         setEditData({...item, date: dateUtil.format(item.date)});
 
@@ -144,6 +145,7 @@ const DetailSchedule = ({isOpen, isRest, restDates, dailyJobs, clickDate, exitBt
 
         setEdit("R");
         setRemove("N");
+        setIsEdit(false);
         setInitData({...item, date: dateUtil.format(new Date(`${item.rest_year}-${item.rest_month}-${item.rest_day}`))});
         setEditData({...item, date: dateUtil.format(new Date(`${item.rest_year}-${item.rest_month}-${item.rest_day}`))});
     }
@@ -547,23 +549,27 @@ const DetailSchedule = ({isOpen, isRest, restDates, dailyJobs, clickDate, exitBt
                                                         <label style={{ marginRight: "5px", fontWeight: "bold", width: "80px" }}>프로젝트</label>
                                                         <div style={{ flex: 1 }}>
                                                             <div style={{height: "40px", display: "flex", alignItems: "center", width: "100%" }}>
-                                                                <Select
-                                                                    onChange={(e) => handleSelect(e)}
-                                                                    options={projectOptions || []} 
-                                                                    value={editData.jno !== undefined ? projectOptions.find(item => item.value === editData.jno) : {}} 
-                                                                    placeholder={"선택하세요"}
-                                                                    menuPortalTarget={document.body}
-                                                                    styles={{
-                                                                        menuPortal: (base) => ({
-                                                                            ...base,
-                                                                            zIndex: 999999999,
-                                                                        }),
-                                                                        container: (provided) => ({
-                                                                        ...provided,
-                                                                        width: "655px",
-                                                                        }),
-                                                                    }}
-                                                                />
+                                                                { nonRest ?
+                                                                    <div> {projectOptions.find(item => item.value === editData.jno)?.label}</div>
+                                                                :
+                                                                    <Select
+                                                                        onChange={(e) => handleSelect(e)}
+                                                                        options={projectOptions || []} 
+                                                                        value={editData.jno !== undefined ? projectOptions.find(item => item.value === editData.jno) : {}} 
+                                                                        placeholder={"선택하세요"}
+                                                                        menuPortalTarget={document.body}
+                                                                        styles={{
+                                                                            menuPortal: (base) => ({
+                                                                                ...base,
+                                                                                zIndex: 999999999,
+                                                                            }),
+                                                                            container: (provided) => ({
+                                                                            ...provided,
+                                                                            width: "655px",
+                                                                            }),
+                                                                        }}
+                                                                    />
+                                                                }
                                                             </div>
                                                         </div>
                                                     </div>

--- a/src/component/layout/content/management/schedule/Schedule.jsx
+++ b/src/component/layout/content/management/schedule/Schedule.jsx
@@ -789,7 +789,8 @@ const Schedule = () => {
 
     // 장비수 변경 이벤트
     const onChangeEquipValue = (value) => {
-        const formatValue = Common.sanitizeNumberInput(value);
+        
+        const formatValue = Common.formatNumber(value);
         setEquip(prev => 
             { return {...prev, cnt:formatValue}});
     }

--- a/src/component/layout/content/management/site/DetailModal.jsx
+++ b/src/component/layout/content/management/site/DetailModal.jsx
@@ -248,11 +248,11 @@ const DetailModal = ({ isOpen, setIsOpen, isEditBtn, title, detailData=[], detai
     /***** 작업완료 *****/
     // 현장 - type: true(작업완료), false(작업완료취소)
     const nonUseCheckOpen = (type) => {
-        const text = type ? "현장 종료 처리" : "현장 종료 취소";
+        const text = type ? "종료" : "종료 취소";
 
         setIsNonUseCheckOpen(true);
         setNonUseCheckFunc(() => () => siteModifyNonUse(type));
-        setNonUseCheckText(`${text}를 하시겠습니까?\n 종료 시 프로젝트도 모두 종료됩니다.`);
+        setNonUseCheckText(`현장 ${text}를 하시겠습니까?\n ${text} 시 프로젝트도 모두 ${text}됩니다.`);
     }
 
     // 현장 작업완료 처리
@@ -494,8 +494,8 @@ const DetailModal = ({ isOpen, setIsOpen, isEditBtn, title, detailData=[], detai
                             {
                                 <div style={{marginRight: "8px", textAlign:"end"}}>
 
-                                    {isRoleValid(siteRoles.SITE_WORK_FINISH) && detailData.is_use === 'Y' && !isEdit && <Button text={"현장 종료"} onClick={() => nonUseCheckOpen(true)}/>}
-                                    {isRoleValid(siteRoles.SITE_WORK_CANCEL) && detailData.is_use !== 'Y' && !isEdit && <Button text={"현장 종료 취소"} style={{}} onClick={() => nonUseCheckOpen(false)}/>}
+                                    {isRoleValid(siteRoles.SITE_WORK_FINISH) && detailData.status === 'Y' && !isEdit && <Button text={"현장 종료"} onClick={() => nonUseCheckOpen(true)}/>}
+                                    {isRoleValid(siteRoles.SITE_WORK_CANCEL) && detailData.status !== 'Y' && !isEdit && <Button text={"현장 종료 취소"} style={{}} onClick={() => nonUseCheckOpen(false)}/>}
 
                                 </div>
                             }

--- a/src/component/layout/content/management/site/DetailProject.jsx
+++ b/src/component/layout/content/management/site/DetailProject.jsx
@@ -118,7 +118,7 @@ const DetailProject = ({data, projectNo, projectLength, isMain, isEdit, onClickD
             const res = await Axios.PUT(`/project/use`, {
                 sno: data.sno || 0,
                 jno: data.jno || 0,
-                is_used : type ? "N" : "Y",
+                is_used : type ? "S" : "Y",
                 mod_uno: user.uno,
                 mod_user: user.userName,
 

--- a/src/component/layout/content/management/site/DetailProject.jsx
+++ b/src/component/layout/content/management/site/DetailProject.jsx
@@ -371,7 +371,7 @@ const DetailProject = ({data, projectNo, projectLength, isMain, isEdit, onClickD
                         :
                         <>
                             {scheduleRole && selectedDate === dateUtil.format(Date.now()) && data?.is_use === "Y"?
-                                <Button text={"작업추가"} onClick={() => onClickAddSchedule()}></Button>
+                                <Button text={"작업내용 추가"} onClick={() => onClickAddSchedule()}></Button>
                             : 
                                 null 
                             }

--- a/src/component/layout/content/management/site/DetailProject.jsx
+++ b/src/component/layout/content/management/site/DetailProject.jsx
@@ -110,9 +110,9 @@ const DetailProject = ({data, projectNo, projectLength, isMain, isEdit, onClickD
 
     const projectModifyNonUse = async (type) => {
         // 프로젝트 타입 별로 axios요청
-        // true면 is_use N
-        // false면 is_use Y로 변경
-        // data의 jno, sno, is_use, is_default
+        // true면 status S
+        // false면 status Y로 변경
+        // data의 jno, sno, status, is_default
         setIsLoading(true);
         try {
             const res = await Axios.PUT(`/project/use`, {
@@ -361,7 +361,7 @@ const DetailProject = ({data, projectNo, projectLength, isMain, isEdit, onClickD
                 nonRest={true}
             />
             {/* 첫 번째 열 */}
-            <div className="form-control grid-project-bc" style={{ gridColumn: "1 / span 2", gridRow: "1", border: "none", color: data?.is_use === "Y" ? "" : nonUseFontColor }}>
+            <div className="form-control grid-project-bc" style={{ gridColumn: "1 / span 2", gridRow: "1", border: "none", color: data?.status === "Y" ? "" : nonUseFontColor }}>
                 <div className="grid-project-title">
                     <span>{`프로젝트 상세 ${projectTitle()}`}</span>
 
@@ -370,13 +370,13 @@ const DetailProject = ({data, projectNo, projectLength, isMain, isEdit, onClickD
                             !isMain && <Button text={"삭제"} style={{marginLeft: "auto"}} onClick={() => onClickDeleteBtn(data.jno)}/>
                         :
                         <>
-                            {scheduleRole && selectedDate === dateUtil.format(Date.now()) && data?.is_use === "Y"?
+                            {scheduleRole && selectedDate === dateUtil.format(Date.now()) && data?.status === "Y"?
                                 <Button text={"작업내용 추가"} onClick={() => onClickAddSchedule()}></Button>
                             : 
                                 null 
                             }
                             {scheduleRole ?
-                                data?.is_use === "Y" ?
+                                data?.status === "Y" ?
                                     <Button text={"프로젝트 종료"} onClick={() => handleJobNonUseCheckOpen(true, data?.jno)}></Button>
                                 :
                                     <Button text={"프로젝트 종료 취소"} onClick={() => handleJobNonUseCheckOpen(false, data?.jno)}></Button>
@@ -395,80 +395,80 @@ const DetailProject = ({data, projectNo, projectLength, isMain, isEdit, onClickD
             </div>
             <div className="form-control grid-project-bc text-none-border" style={{ gridColumn: "1", gridRow: "2" }}>
                 <div className="text-overflow">
-                    <label className="detail-text-label" style={{color: data?.is_use === "Y" ? "" : nonUseFontColor }}>
+                    <label className="detail-text-label" style={{color: data?.status === "Y" ? "" : nonUseFontColor }}>
                         코드
                     </label>
-                    <div className="read-only-input" style={{color: data?.is_use === "Y" ? "" : nonUseFontColor }}>
+                    <div className="read-only-input" style={{color: data?.status === "Y" ? "" : nonUseFontColor }}>
                         {data.project_no}
                     </div>
                 </div>
             </div>
             <div className="form-control grid-project-bc text-none-border" style={{ gridColumn: "1", gridRow: "3" }}>
                 <div className="text-overflow">
-                    <label className="detail-text-label" style={{color: data?.is_use === "Y" ? "" : nonUseFontColor }}>
+                    <label className="detail-text-label" style={{color: data?.status === "Y" ? "" : nonUseFontColor }}>
                         등록일
                     </label>
-                    <div className="read-only-input" style={{color: data?.is_use === "Y" ? "" : nonUseFontColor }}>
+                    <div className="read-only-input" style={{color: data?.status === "Y" ? "" : nonUseFontColor }}>
                         {dateUtil.format(data.reg_date)}{dateUtil.isDate(data.mod_date) ? ` (수정일: ${dateUtil.format(data.mod_date)})` : ""}
                     </div>
                 </div>
             </div>
             <div className="form-control grid-project-bc text-none-border" style={{ gridColumn: "1", gridRow: "4" }}>
                 <div className="text-overflow">
-                    <label className="detail-text-label" style={{color: data?.is_use === "Y" ? "" : nonUseFontColor }}>
+                    <label className="detail-text-label" style={{color: data?.status === "Y" ? "" : nonUseFontColor }}>
                         착수년도
                     </label>
-                    <div className="read-only-input" style={{color: data?.is_use === "Y" ? "" : nonUseFontColor }}>
+                    <div className="read-only-input" style={{color: data?.status === "Y" ? "" : nonUseFontColor }}>
                         {data.project_year}
                     </div>
                 </div>
             </div>
             <div className="form-control grid-project-bc text-none-border" style={{ gridColumn: "1", gridRow: "5" }}>
                 <div className="text-overflow">
-                    <label className="detail-text-label" style={{color: data?.is_use === "Y" ? "" : nonUseFontColor }}>
+                    <label className="detail-text-label" style={{color: data?.status === "Y" ? "" : nonUseFontColor }}>
                         업무 코드
                     </label>
-                    <div className="read-only-input" style={{color: data?.is_use === "Y" ? "" : nonUseFontColor }}>
+                    <div className="read-only-input" style={{color: data?.status === "Y" ? "" : nonUseFontColor }}>
                         {data.project_code_name}
                     </div>
                 </div>
             </div>
             <div className="form-control grid-project-bc text-none-border" style={{ gridColumn: "1", gridRow: "6" }}>
                 <div className="text-overflow">
-                    <label className="detail-text-label" style={{color: data?.is_use === "Y" ? "" : nonUseFontColor }}>
+                    <label className="detail-text-label" style={{color: data?.status === "Y" ? "" : nonUseFontColor }}>
                         시작(착수)일
                     </label>
-                    <div className="read-only-input" style={{color: data?.is_use === "Y" ? "" : nonUseFontColor }}>
+                    <div className="read-only-input" style={{color: data?.status === "Y" ? "" : nonUseFontColor }}>
                         {dateUtil.format(data.project_stdt)}
                     </div>
                 </div>
             </div>
             <div className="form-control grid-project-bc text-none-border" style={{ gridColumn: "1", gridRow: "7" }}>
                 <div className="text-overflow">
-                    <label className="detail-text-label" style={{color: data?.is_use === "Y" ? "" : nonUseFontColor }}>
+                    <label className="detail-text-label" style={{color: data?.status === "Y" ? "" : nonUseFontColor }}>
                         PM
                     </label>
-                    <div className="read-only-input" style={{color: data?.is_use === "Y" ? "" : nonUseFontColor }}>
+                    <div className="read-only-input" style={{color: data?.status === "Y" ? "" : nonUseFontColor }}>
                         {data.job_pm_nm}
                     </div>
                 </div>
             </div>
             <div className="form-control grid-project-bc text-none-border" style={{ gridColumn: "1", gridRow: "8" }}>
                 <div className="text-overflow">
-                    <label className="detail-text-label" style={{color: data?.is_use === "Y" ? "" : nonUseFontColor }}>
+                    <label className="detail-text-label" style={{color: data?.status === "Y" ? "" : nonUseFontColor }}>
                         고객사
                     </label>
-                    <div className="read-only-input" style={{color: data?.is_use === "Y" ? "" : nonUseFontColor }}>
+                    <div className="read-only-input" style={{color: data?.status === "Y" ? "" : nonUseFontColor }}>
                         {data.comp_name}
                     </div>
                 </div>
             </div>
             <div className="form-control grid-project-bc text-none-border" style={{ gridColumn: "1 / span 2", gridRow: "9" }}>
                 <div className="text-overflow">
-                    <label className="detail-text-label" style={{width: "130px", color: data?.is_use === "Y" ? "" : nonUseFontColor }}>
+                    <label className="detail-text-label" style={{width: "130px", color: data?.status === "Y" ? "" : nonUseFontColor }}>
                         공정률
                     </label>
-                    <div className="read-only-input" style={{color: data?.is_use === "Y" ? "" : nonUseFontColor }}>
+                    <div className="read-only-input" style={{color: data?.status === "Y" ? "" : nonUseFontColor }}>
                         {
                             isEdit && checkAllowDate(data.cancel_day) ?
                                 <input className="slider-input" type="text" value={sliderValue} onChange={(e) => onChangeSliderValue(e.target.value)} style={{height: "40px", width: "50px", textAlign: "right", paddingRight: "5px"}}/>
@@ -490,10 +490,10 @@ const DetailProject = ({data, projectNo, projectLength, isMain, isEdit, onClickD
             </div>
             <div className="form-control grid-project-bc" style={{ gridColumn: "1 / span 2", gridRow: "10", border: "none" }}>
                 <div className="d-flex">
-                    <label className="detail-text-label" style={{width: "130px", color: data?.is_use === "Y" ? "" : nonUseFontColor }}>
+                    <label className="detail-text-label" style={{width: "130px", color: data?.status === "Y" ? "" : nonUseFontColor }}>
                         작업내용
                     </label>
-                    <div className="read-only-input" onClick={() => onClickScheduleOpen(data.daily_content_list)}  style={{color: data?.is_use === "Y" ? "" : nonUseFontColor }}>
+                    <div className="read-only-input" onClick={() => onClickScheduleOpen(data.daily_content_list)}  style={{color: data?.status === "Y" ? "" : nonUseFontColor }}>
                         <div className="">
 
                         {data.daily_content_list.length > 0 ?
@@ -513,70 +513,70 @@ const DetailProject = ({data, projectNo, projectLength, isMain, isEdit, onClickD
             {/* 두번째 열 */}
             <div className="form-control grid-project-bc text-none-border" style={{ gridColumn: "2", gridRow: "2" }}>
                 <div className="text-overflow">
-                    <label className="detail-text-label" style={{color: data?.is_use === "Y" ? "" : nonUseFontColor }}>
+                    <label className="detail-text-label" style={{color: data?.status === "Y" ? "" : nonUseFontColor }}>
                         진행상태
                     </label>
-                    <div className="read-only-input" style={{color: data?.is_use === "Y" ? "" : nonUseFontColor }}>
+                    <div className="read-only-input" style={{color: data?.status === "Y" ? "" : nonUseFontColor }}>
                         {data.project_state_nm}
                     </div>
                 </div>
             </div>
             <div className="form-control grid-project-bc text-none-border" style={{ gridColumn: "2", gridRow: "3" }}>
                 <div className="text-overflow">
-                    <label className="detail-text-label" style={{color: data?.is_use === "Y" ? "" : nonUseFontColor }}>
+                    <label className="detail-text-label" style={{color: data?.status === "Y" ? "" : nonUseFontColor }}>
                         프로젝트명
                     </label>
-                    <div className="read-only-input" style={{color: data?.is_use === "Y" ? "" : nonUseFontColor }}>
+                    <div className="read-only-input" style={{color: data?.status === "Y" ? "" : nonUseFontColor }}>
                         {data.project_nm}
                     </div>
                 </div>
             </div>
             <div className="form-control grid-project-bc text-none-border" style={{ gridColumn: "2", gridRow: "4" }}>
                 <div className="text-overflow">
-                    <label className="detail-text-label" style={{color: data?.is_use === "Y" ? "" : nonUseFontColor }}>
+                    <label className="detail-text-label" style={{color: data?.status === "Y" ? "" : nonUseFontColor }}>
                         사업소
                     </label>
-                    <div className="read-only-input" style={{color: data?.is_use === "Y" ? "" : nonUseFontColor }}>
+                    <div className="read-only-input" style={{color: data?.status === "Y" ? "" : nonUseFontColor }}>
                         {data.project_loc_name}
                     </div>
                 </div>
             </div>
             <div className="form-control grid-project-bc text-none-border" style={{ gridColumn: "2", gridRow: "5" }}>
                 <div className="text-overflow">
-                    <label className="detail-text-label" style={{color: data?.is_use === "Y" ? "" : nonUseFontColor }}>
+                    <label className="detail-text-label" style={{color: data?.status === "Y" ? "" : nonUseFontColor }}>
                         프로젝트 유형
                     </label>
-                    <div className="read-only-input" style={{color: data?.is_use === "Y" ? "" : nonUseFontColor }}>
+                    <div className="read-only-input" style={{color: data?.status === "Y" ? "" : nonUseFontColor }}>
                         {data.project_type_nm}
                     </div>
                 </div>
             </div>
             <div className="form-control grid-project-bc text-none-border" style={{ gridColumn: "2", gridRow: "6" }}>
                 <div className="text-overflow">
-                    <label className="detail-text-label" style={{color: data?.is_use === "Y" ? "" : nonUseFontColor }}>
+                    <label className="detail-text-label" style={{color: data?.status === "Y" ? "" : nonUseFontColor }}>
                         종료(예정)일
                     </label>
-                    <div className="read-only-input" style={{color: data?.is_use === "Y" ? "" : nonUseFontColor }}>
+                    <div className="read-only-input" style={{color: data?.status === "Y" ? "" : nonUseFontColor }}>
                         {dateUtil.format(data.project_eddt)}
                     </div>
                 </div>
             </div>
             <div className="form-control grid-project-bc text-none-border" style={{ gridColumn: "2", gridRow: "7" }}>
                 <div className="text-overflow">
-                    <label className="detail-text-label" style={{color: data?.is_use === "Y" ? "" : nonUseFontColor }}>
+                    <label className="detail-text-label" style={{color: data?.status === "Y" ? "" : nonUseFontColor }}>
                         PE
                     </label>
-                    <div className="read-only-input" style={{color: data?.is_use === "Y" ? "" : nonUseFontColor }}>
+                    <div className="read-only-input" style={{color: data?.status === "Y" ? "" : nonUseFontColor }}>
                         {peTextJoin()}
                     </div>
                 </div>
             </div>
             <div className="form-control grid-project-bc text-none-border" style={{ gridColumn: "2", gridRow: "8" }}>
                 <div className="text-overflow">
-                    <label className="detail-text-label" style={{color: data?.is_use === "Y" ? "" : nonUseFontColor }}>
+                    <label className="detail-text-label" style={{color: data?.status === "Y" ? "" : nonUseFontColor }}>
                         발주처
                     </label>
-                    <div className="read-only-input" style={{color: data?.is_use === "Y" ? "" : nonUseFontColor }}>
+                    <div className="read-only-input" style={{color: data?.status === "Y" ? "" : nonUseFontColor }}>
                         {data.order_comp_name}
                     </div>
                 </div>

--- a/src/component/layout/content/management/site/DetailProject.jsx
+++ b/src/component/layout/content/management/site/DetailProject.jsx
@@ -493,8 +493,8 @@ const DetailProject = ({data, projectNo, projectLength, isMain, isEdit, onClickD
                     <label className="detail-text-label" style={{width: "130px", color: data?.status === "Y" ? "" : nonUseFontColor }}>
                         작업내용
                     </label>
-                    <div className="read-only-input" onClick={() => onClickScheduleOpen(data.daily_content_list)}  style={{color: data?.status === "Y" ? "" : nonUseFontColor }}>
-                        <div className="">
+                    <div className="read-only-input work" onClick={() => onClickScheduleOpen(data.daily_content_list)}  style={{color: data?.status === "Y" ? "" : nonUseFontColor }}>
+                        <div className="" style={{whiteSpace:"pre-line"}}>
 
                         {data.daily_content_list.length > 0 ?
                             // 작업내용이 여러개인 경우

--- a/src/component/layout/content/management/site/DetailSite.jsx
+++ b/src/component/layout/content/management/site/DetailSite.jsx
@@ -275,7 +275,7 @@ const DetailSite = ({isEdit, detailData, detailWeather, projectData, handleChang
                     </label>
                     <div className="form-input" style={{ flex: 1 }}>
                         {isEdit && !isNonUseChecked ? (
-                            <DateInput time={openingDate} setTime={setOpeningDate}></DateInput>
+                            <DateInput time={openingDate} setTime={setOpeningDate} isRefresh={false}></DateInput>
                         ) : (
                             <div className="read-only-input">
                                 {dateUtil.format(data?.site_date?.opening_date)}
@@ -291,7 +291,7 @@ const DetailSite = ({isEdit, detailData, detailWeather, projectData, handleChang
                     </label>
                     <div className="form-input" style={{ flex: 1 }}>
                         {isEdit && !isNonUseChecked ? (
-                            <DateInput time={closingPlanDate} setTime={setClosingPlanDate}></DateInput>
+                            <DateInput time={closingPlanDate} setTime={setClosingPlanDate} isRefresh={false}></DateInput>
                         ) : (
                             <div className="read-only-input">
                                 {dateUtil.format(data?.site_date?.closing_plan_date)}
@@ -307,7 +307,7 @@ const DetailSite = ({isEdit, detailData, detailWeather, projectData, handleChang
                     </label>
                     <div className="form-input" style={{ flex: 1 }}>
                         {isEdit && !isNonUseChecked ? (
-                            <DateInput time={closingForecastDate} setTime={setClosingForecastDate}></DateInput>
+                            <DateInput time={closingForecastDate} setTime={setClosingForecastDate} isRefresh={false}></DateInput>
                         ) : (
                             <div className="read-only-input">
                                 {dateUtil.format(data?.site_date?.closing_forecast_date)}
@@ -323,7 +323,7 @@ const DetailSite = ({isEdit, detailData, detailWeather, projectData, handleChang
                     </label>
                     <div className="form-input" style={{ flex: 1 }}>
                         {isEdit ? (
-                            <DateInput time={closingActualDate} setTime={setClosingActualDate}></DateInput>
+                            <DateInput time={closingActualDate} setTime={setClosingActualDate} isRefresh={false}></DateInput>
                         ) : (
                             <div className="read-only-input">
                                 {dateUtil.format(data?.site_date?.closing_actual_date)}

--- a/src/component/layout/content/management/site/Site.jsx
+++ b/src/component/layout/content/management/site/Site.jsx
@@ -587,7 +587,6 @@ const Site = () => {
             <div className="container-fluid px-4">
                 <ol className="breadcrumb mb-2 content-title-box">
                     <li className="breadcrumb-item content-title">현장목록</li>
-                    <li className="breadcrumb-item active content-title-sub">관리</li>
                     <div className="table-header-right">
                         {isRoleValid(siteRoles.SITE_ADD) && selectedDate === dateUtil.format(Date.now()) && <Button text={"추가"} onClick={() => onClickSaveBtn()} />}
                     </div>
@@ -602,6 +601,7 @@ const Site = () => {
                                 setTime={(value) => setSelectedDate(value)} 
                                 dateInputStyle={{margin: "0px", marginLeft:"10px"}}
                                 calendarPopupStyle={{ fontWeight: "normal"}}
+                                isRefresh={true}
                             ></DateInput>
                         </div>
                         <div className="square-container">

--- a/src/component/layout/content/management/site/Site.jsx
+++ b/src/component/layout/content/management/site/Site.jsx
@@ -107,9 +107,9 @@ const Site = () => {
 
     // 현장 리스트 바꾸기 (작업완료|진행중)
     const onClickNonUseList = () =>{
-        dispatch({type: isNonUseChecked ? "USE_LIST" : "NON_USE_LIST"});
+        dispatch({type: "LIST"});
         setIsNonUseChecked(!isNonUseChecked);
-
+        refetch(true, false);
     }
 
     // 현장 상세
@@ -394,7 +394,7 @@ const Site = () => {
 
     // 현장 정보 조회
     const {cacheData, isStale, isFetchedLoading, refetch} = useCachedFetch(
-        `/site?targetDate=${dateUtil.format(selectedDate, "yyyy-MM-dd")}&pCode=SITE_STATUS&isRole=${isRoleValid(siteRoles.SITE_LIST)}`,
+        `/site?targetDate=${dateUtil.format(selectedDate, "yyyy-MM-dd")}&pCode=SITE_STATUS&isRole=${isRoleValid(siteRoles.SITE_LIST)}&isNonUse=${isNonUseChecked}`,
 
         {
             storageKey: `siteData_${dateUtil.format(selectedDate, "yyyy-MM-dd")}`,
@@ -418,13 +418,12 @@ const Site = () => {
             },
             onFinally: ({ isCache, isRefetch }) => {
                 if(!isCache){
-                    setIsLoading(false);
                     setIsNonUseChecked(false);
                 }
                 if(isCache && isRefetch) {
-                    setIsLoading(false);
                     setIsNonUseChecked(false);
                 }
+                setIsLoading(false);
             }
         }
     );
@@ -552,6 +551,7 @@ const Site = () => {
                 text={modalText}
                 confirm={"확인"}
                 fncConfirm={() => setIsOpenModal(false)}
+                isConfirmFocus={true}
             />
             <Modal
                 isOpen={isModal2}

--- a/src/component/layout/content/management/site/Site.jsx
+++ b/src/component/layout/content/management/site/Site.jsx
@@ -108,8 +108,8 @@ const Site = () => {
     // 현장 리스트 바꾸기 (작업완료|진행중)
     const onClickNonUseList = () =>{
         dispatch({type: "LIST"});
-        setIsNonUseChecked(!isNonUseChecked);
-        refetch(true, false);
+        setIsNonUseChecked(prev => !prev);
+        // refetch(true, false);
     }
 
     // 현장 상세
@@ -397,7 +397,7 @@ const Site = () => {
         `/site?targetDate=${dateUtil.format(selectedDate, "yyyy-MM-dd")}&pCode=SITE_STATUS&isRole=${isRoleValid(siteRoles.SITE_LIST)}&isNonUse=${isNonUseChecked}`,
 
         {
-            storageKey: `siteData_${dateUtil.format(selectedDate, "yyyy-MM-dd")}`,
+            storageKey: `siteData_${dateUtil.format(selectedDate, "yyyy-MM-dd")}_isNonUse_${isNonUseChecked}`,
             useSession: true,
             delaySecondsAfterCache: 2,
             onCacheLoad: (cache) => {
@@ -418,12 +418,13 @@ const Site = () => {
             },
             onFinally: ({ isCache, isRefetch }) => {
                 if(!isCache){
-                    setIsNonUseChecked(false);
+                    // setIsNonUseChecked(false);
+                    setIsLoading(false);
                 }
                 if(isCache && isRefetch) {
-                    setIsNonUseChecked(false);
+                    // setIsNonUseChecked(false);
+                    setIsLoading(false);
                 }
-                setIsLoading(false);
             }
         }
     );

--- a/src/component/layout/content/management/site/SiteReducer.js
+++ b/src/component/layout/content/management/site/SiteReducer.js
@@ -36,7 +36,7 @@ const SiteReducer = (state, action) => {
                 
                 if (Array.isArray(projectList) && projectList.length > 1) {
                     projectList.forEach(item => {
-                        sites.push({...item, type: "sub", is_parent_use: site.is_use}); // useSites, nonUseSite 분리하는 부분에서 작업완료된 프로젝트가 현장이 작업 완료 안됬는데 nonUseSite 때문에 부모 완료여부(is_parent_use)를 추가함
+                        sites.push({...item, type: "sub"});
                     });
                 }
             });
@@ -66,11 +66,7 @@ const SiteReducer = (state, action) => {
                     return { ...obj, daily_content_list: contents };
                 }
             });
-
-            const useSites = newSites.filter(item => item.is_use === 'Y' || item?.is_parent_use === 'Y');
-            const nonUseSite = newSites.filter(item => item.is_use !== 'Y' && item?.is_parent_use !== 'Y');
-            
-            return {...state, list: JSON.parse(JSON.stringify(useSites)), useList: JSON.parse(JSON.stringify(useSites)), nonUseList: JSON.parse(JSON.stringify(nonUseSite)), code: JSON.parse(JSON.stringify(action.code)), dailyTotalCount: JSON.parse(JSON.stringify(total))};
+            return {...state, list: JSON.parse(JSON.stringify(newSites)), code: JSON.parse(JSON.stringify(action.code)), dailyTotalCount: JSON.parse(JSON.stringify(total))};
         case "STATS":
             const setColor2 = (code) => {
                 const foundItem = state?.code?.find(item => item.code === code);
@@ -152,10 +148,9 @@ const SiteReducer = (state, action) => {
             });
             return {...state, dailyWeather: structuredClone(weathers)};
 
-        case "USE_LIST":
+        case "LIST":
             return {...state, list: state.useList};
-        case "NON_USE_LIST":
-            return {...state, list: state.nonUseList};
+
 
         default:
             return state;

--- a/src/component/module/DateInput.jsx
+++ b/src/component/module/DateInput.jsx
@@ -7,6 +7,7 @@ import "../../assets/css/DateInput.css";
 import "../../assets/css/Tooltip.css";
 import CalendarIcon from "../../assets/image/calendar-icon.png";
 import RefreshIcon from "../../assets/image/refresh-icon.png";
+import CancelIcon from "../../assets/image/cancel.png";
 import { dateUtil } from "../../utils/DateUtil";
 import { Axios } from "../../utils/axios/Axios.js";
 import OutsideClick from "./OutsideClick.jsx";
@@ -30,10 +31,11 @@ import OutsideClick from "./OutsideClick.jsx";
  *  dateInputStyle: 날짜가 담기는 div의 스타일
  *  caenderPopupStyle: 달력 스타일 지정
  *  isCalendarHide: 달력 표시 여부
- *  minDate: 날짜 제한(기본값: null (제한없음), 입략 형태: Date()))
+ *  minDate: 날짜 제한(기본값: null (제한없음), 입력 형태: Date()))
+ *  isRefresh: 초기화 형태(기본값: true, true:오늘 날짜 false: "-")
  * 
  */
-const DateInput = ({time, setTime, dateInputStyle, calendarPopupStyle, isCalendarHide, minDate = null}) => {
+const DateInput = ({time, setTime, dateInputStyle, calendarPopupStyle, isCalendarHide, minDate = null, isRefresh = true}) => {
 
     const [showCalendar, setShowCalendar] = useState(false);
 
@@ -102,12 +104,14 @@ const DateInput = ({time, setTime, dateInputStyle, calendarPopupStyle, isCalenda
         <span className="calendar-wrapper">
             <div className="date-input" style={{...dateInputStyle}}>
                 <input type="date" id="inputDate" value={time} max="9999-12-31" className="inputBox" onChange={(e) => setTime(e.target.value)} />
-                {
-                    <input type="image" value="" src={RefreshIcon} className="imgIcon" onClick={() => setTime("-")} style={{margin:"0 0.5rem"}}/>
+                { isRefresh ?
+                    <input type="image" value="" src={RefreshIcon} className="imgIcon" onClick={() => setTime(dateUtil.format(new Date()))} style={{margin:"0 0.25rem"}}/>
+                    :
+                    <input type="image" value="" src={CancelIcon} className="imgIcon" onClick={() => setTime("-")} style={{margin:"0 0.25rem",opacity: 0.5 }}/>
                 }
                 {
                     isCalendarHide ? null
-                    : <input type="image" value="" src={CalendarIcon} className="imgIcon" onClick={() => setShowCalendar(prev => !prev)}/>               
+                    : <input type="image" value="" src={CalendarIcon} className="imgIcon" onClick={() => setShowCalendar(prev => !prev)} />               
                 }
 
             </div>

--- a/src/component/module/search/Search.jsx
+++ b/src/component/module/search/Search.jsx
@@ -98,7 +98,7 @@ const Search = ({searchOptions=[], width, height="auto", fncSearchKeywords, retr
         
         setKeyword(newKeyword);
         fncSearchKeywords(setSearchKeyword(newKeyword));
-        setText("");
+        if (isReSearch) {setText("")};
     };
 
     // 검색어 텍스트로 변환

--- a/src/utils/hooks/useCachedFetch.js
+++ b/src/utils/hooks/useCachedFetch.js
@@ -107,7 +107,6 @@ export function useCachedFetch(url, options = {}) {
             const result = res ?? null;
             setCacheData(result);
             setIsStale(false);
-            setIsFetchedLoading(false);
 
             if (useCache && saveCache) {
                 // 캐시 저장
@@ -119,7 +118,7 @@ export function useCachedFetch(url, options = {}) {
         } catch (err) {
             if (myRequestId !== apiRequestMap[apiKey]) return;
             if (!isMounted.current) return;
-            setIsFetchedLoading(false);
+            
 
             // 실패 콜백
             errorRef.current(err);
@@ -127,6 +126,7 @@ export function useCachedFetch(url, options = {}) {
             if (myRequestId !== apiRequestMap[apiKey]) return;
             if (!isMounted.current) return;
             // 호출 마무리 실행 콜백
+            setIsFetchedLoading(false);
             finallyRef.current({ isCache, isRefetch });
         }
     }, [url, storageKey, storage, useCache]);


### PR DESCRIPTION
1. [검색] 단일 검색 시 검색 텍스트 유지
2. [현장목록] 작업 완료 체크 시 종료된 전체 현장 확인 가능하도록, 변경 및 작업추가 버튼 수정]
3. [프로젝트] 프로젝트 status로 관리하기 위해 종료 시 상태 'S'로 보내기.
4. [현장관리] is_use로 관리하던 것 status로 관리
5. [날짜 및 현장상세] 날짜 refresh, cancel 두가지 형태로 분리, 현장 상세 작업내용 호버 및 칸 늘이기
6. [일정] 현장목록에서 작업내용 수정/추가 시 프로젝트 변경 못하도록 막기